### PR TITLE
Adds support for bridging Ant+ Heart Rate measurements to Bluetooth

### DIFF
--- a/app/src/main/java/idv/markkuo/cscblebridge/MainActivity.java
+++ b/app/src/main/java/idv/markkuo/cscblebridge/MainActivity.java
@@ -15,12 +15,13 @@ import android.view.View;
 import android.widget.Button;
 import android.widget.TextView;
 
+
 public class MainActivity extends AppCompatActivity {
     private static final String TAG = MainActivity.class.getSimpleName();
 
-    private TextView tv_speedSensorState, tv_cadenceSensorState,
-            tv_speedSensorTimestamp, tv_cadenceSensorTimestamp,
-            tv_speed, tv_cadence;
+    private TextView tv_speedSensorState, tv_cadenceSensorState, tv_hrSensorState,
+            tv_speedSensorTimestamp, tv_cadenceSensorTimestamp, tv_hrSensorTimestamp,
+            tv_speed, tv_cadence, tv_hr;
     private Button btn_service;
 
     private boolean serviceStarted = false;
@@ -33,11 +34,15 @@ public class MainActivity extends AppCompatActivity {
 
         tv_speedSensorState = findViewById(R.id.SpeedSensorStateText);
         tv_cadenceSensorState = findViewById(R.id.CadenceSensorStateText);
+        tv_hrSensorState = findViewById(R.id.HRSensorStateText);
+
         tv_speedSensorTimestamp = findViewById(R.id.SpeedTimestampText);
         tv_cadenceSensorTimestamp = findViewById(R.id.CadenceTimestampText);
+        tv_hrSensorTimestamp = findViewById(R.id.HRSensorStateText);
 
         tv_speed = findViewById(R.id.SpeedText);
         tv_cadence = findViewById(R.id.CadenceText);
+        tv_hr = findViewById(R.id.HRText);
         btn_service = findViewById(R.id.ServiceButton);
 
         if (isServiceRunning()) {
@@ -103,10 +108,13 @@ public class MainActivity extends AppCompatActivity {
     private void resetUi() {
         tv_speedSensorState.setText(getText(R.string.no_data));
         tv_cadenceSensorState.setText(getText(R.string.no_data));
+        tv_hrSensorState.setText(getText(R.string.no_data));
         tv_speedSensorTimestamp.setText(getText(R.string.no_data));
         tv_cadenceSensorTimestamp.setText(getText(R.string.no_data));
+        tv_hrSensorTimestamp.setText(getText(R.string.no_data));
         tv_speed.setText(getText(R.string.no_data));
         tv_cadence.setText(getText(R.string.no_data));
+        tv_hr.setText(getText(R.string.no_data));
     }
 
     private boolean isServiceRunning() {
@@ -126,10 +134,13 @@ public class MainActivity extends AppCompatActivity {
         public void onReceive(Context context, Intent intent) {
             final String statusBSD = intent.getStringExtra("bsd_service_status");
             final String statusBC = intent.getStringExtra("bc_service_status");
+            final String statusHR = intent.getStringExtra("hr_service_status");
             final long speedTimestamp = intent.getLongExtra("speed_timestamp", -1);
             final long cadenceTimestamp = intent.getLongExtra("cadence_timestamp", -1);
+            final long hrTimestamp = intent.getLongExtra("hr_timestamp", -1);
             final float speed = intent.getFloatExtra("speed", -1.0f);
             final int cadence = intent.getIntExtra("cadence", -1);
+            final int hr = intent.getIntExtra("hr", -1);
 
             runOnUiThread(new Runnable() {
                 @SuppressLint("DefaultLocale")
@@ -139,14 +150,20 @@ public class MainActivity extends AppCompatActivity {
                         tv_speedSensorState.setText(statusBSD);
                     if (statusBC != null)
                         tv_cadenceSensorState.setText(statusBC);
+                    if (statusHR != null)
+                        tv_hrSensorState.setText(statusHR);
                     if (speedTimestamp >= 0)
                         tv_speedSensorTimestamp.setText(String.valueOf(speedTimestamp));
                     if (cadenceTimestamp >= 0)
                         tv_cadenceSensorTimestamp.setText(String.valueOf(cadenceTimestamp));
+                    if (hrTimestamp >= 0)
+                        tv_cadenceSensorTimestamp.setText(String.valueOf(hrTimestamp));
                     if (speed >= 0.0f)
                         tv_speed.setText(String.format("%.02f", speed));
                     if (cadence >= 0)
                         tv_cadence.setText(String.valueOf(cadence));
+                    if (hr >= 0)
+                        tv_hr.setText(String.valueOf(hr));
                 }
             });
         }

--- a/app/src/main/res/layout-land/activity_main.xml
+++ b/app/src/main/res/layout-land/activity_main.xml
@@ -4,6 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:layout_margin="10sp"
     tools:context="idv.markkuo.cscblebridge.MainActivity">
 
     <LinearLayout
@@ -28,6 +29,13 @@
                 android:layout_height="wrap_content"
                 android:layout_weight="1"
                 android:text="@string/cadence_sensor" />
+
+            <TextView
+                android:id="@+id/textView9"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="@string/hr_sensor" />
         </LinearLayout>
 
         <LinearLayout
@@ -50,6 +58,14 @@
                 android:layout_weight="1"
                 android:text="@string/no_data"
                 android:textSize="18sp" />
+
+            <TextView
+                android:id="@+id/HRSensorStateText"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="@string/no_data"
+                android:textSize="14sp" />
         </LinearLayout>
 
         <LinearLayout
@@ -66,6 +82,13 @@
 
             <TextView
                 android:id="@+id/textView3"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="@string/timestamp" />
+
+            <TextView
+                android:id="@+id/textView11"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_weight="1"
@@ -92,6 +115,14 @@
                 android:layout_weight="1"
                 android:text="@string/no_data"
                 android:textSize="20sp" />
+
+            <TextView
+                android:id="@+id/HRTimestampText"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="@string/no_data"
+                android:textSize="20sp" />
         </LinearLayout>
 
         <Space
@@ -113,9 +144,16 @@
             <TextView
                 android:id="@+id/textView6"
                 android:layout_width="0dp"
-                android:layout_height="wrap_content"
+                android:layout_height="match_parent"
                 android:layout_weight="1"
                 android:text="@string/cadence" />
+
+            <TextView
+                android:id="@+id/textView13"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="@string/heart_rate" />
         </LinearLayout>
 
         <LinearLayout
@@ -135,6 +173,14 @@
             <TextView
                 android:id="@+id/CadenceText"
                 android:layout_width="0dp"
+                android:layout_height="match_parent"
+                android:layout_weight="1"
+                android:text="@string/no_data"
+                android:textSize="64sp" />
+
+            <TextView
+                android:id="@+id/HRText"
+                android:layout_width="0sp"
                 android:layout_height="match_parent"
                 android:layout_weight="1"
                 android:text="@string/no_data"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -4,6 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:layout_margin="10sp"
     tools:context="idv.markkuo.cscblebridge.MainActivity">
 
     <LinearLayout
@@ -28,6 +29,13 @@
                 android:layout_height="wrap_content"
                 android:layout_weight="1"
                 android:text="@string/cadence_sensor" />
+
+            <TextView
+                android:id="@+id/textView7"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="@string/hr_sensor" />
         </LinearLayout>
 
         <LinearLayout
@@ -41,7 +49,7 @@
                 android:layout_height="wrap_content"
                 android:layout_weight="1"
                 android:text="@string/no_data"
-                android:textSize="18sp" />
+                android:textSize="14sp" />
 
             <TextView
                 android:id="@+id/CadenceSensorStateText"
@@ -49,13 +57,28 @@
                 android:layout_height="wrap_content"
                 android:layout_weight="1"
                 android:text="@string/no_data"
-                android:textSize="18sp" />
+                android:textSize="14sp" />
+
+            <TextView
+                android:id="@+id/HRSensorStateText"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="@string/no_data"
+                android:textSize="14sp" />
         </LinearLayout>
 
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="horizontal">
+
+            <TextView
+                android:id="@+id/textView8"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="@string/timestamp" />
 
             <TextView
                 android:id="@+id/textView5"
@@ -83,7 +106,7 @@
                 android:layout_height="wrap_content"
                 android:layout_weight="1"
                 android:text="@string/no_data"
-                android:textSize="20sp" />
+                android:textSize="14sp" />
 
             <TextView
                 android:id="@+id/CadenceTimestampText"
@@ -91,7 +114,15 @@
                 android:layout_height="wrap_content"
                 android:layout_weight="1"
                 android:text="@string/no_data"
-                android:textSize="20sp" />
+                android:textSize="14sp" />
+
+            <TextView
+                android:id="@+id/HRTimestampText"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="@string/no_data"
+                android:textSize="14sp" />
         </LinearLayout>
 
         <Space
@@ -120,6 +151,20 @@
 
         <TextView
             android:id="@+id/CadenceText"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="1"
+            android:text="@string/no_data"
+            android:textSize="64sp" />
+
+        <TextView
+            android:id="@+id/textView"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/heart_rate" />
+
+        <TextView
+            android:id="@+id/HRText"
             android:layout_width="match_parent"
             android:layout_height="0dp"
             android:layout_weight="1"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -6,6 +6,8 @@
     <string name="current_speed">Current Speed on 700x23C tire (km/h)</string>
     <string name="speed_sensor">Speed Sensor</string>
     <string name="cadence_sensor">Cadence Sensor</string>
+    <string name="hr_sensor">HR sensor</string>
     <string name="timestamp">TimeStamp</string>
     <string name="cadence">Current Cadence (rpm)</string>
+    <string name="heart_rate">Heart rate (bpm)</string>
 </resources>


### PR DESCRIPTION
Adds support for receiving Ant+ Heart Rate measurements and bridges this to Bluetooth.

The HR is also shown on screen along with Speed and Cadence.

This code has been tested with a Garmin Fenix 5S with Broadcast mode on, to a Samsung Galaxy S9.

I have tried to adhere to your coding style as much as possible. 