### PR TITLE
Added support for long-holding on a sensor name to rescan

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This is an Android app which reads ANT+ cycling speed/cadence (CSC) and/or heart
 
 This is useful when you only have ANT+ CSC/HR sensors but you want to connect to them as BLE sensors (provided that you don't have an USB ANT+ stick around but happen to have an ANT+ enabled Android device like a Samsung phone).
 
+Long hold on the sensors name on top of the screen to rescan for Ant+ devices after the "Start BLE bridging" button has been pressed. All sensors will automatically scan for Ant+ sources when the "Start BLE bridging" button is pressed.
 
 # Why
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -4,6 +4,11 @@ android {
     compileSdkVersion 30
     buildToolsVersion "29.0.3"
 
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
     defaultConfig {
         applicationId "idv.markkuo.cscblebridge"
         minSdkVersion 21

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -14,6 +14,7 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:usesCleartextTraffic="true"
+        android:launchMode="singleTop"
         android:theme="@style/AppTheme">
         <activity android:name="idv.markkuo.cscblebridge.MainActivity">
             <intent-filter>

--- a/app/src/main/java/idv/markkuo/cscblebridge/CSCService.java
+++ b/app/src/main/java/idv/markkuo/cscblebridge/CSCService.java
@@ -268,24 +268,21 @@ public class CSCService extends Service {
     public int onStartCommand(Intent intent, int flags, int startId) {
         Log.d(TAG, "Service onStartCommand");
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            Intent notificationIntent = new Intent(this, CSCService.class);
-            PendingIntent pendingIntent =
-                    PendingIntent.getActivity(this, 0, notificationIntent, 0);
-
-            int importance = NotificationManager.IMPORTANCE_DEFAULT;
-            NotificationChannel channel = new NotificationChannel(CHANNEL_DEFAULT_IMPORTANCE, CHANNEL_DEFAULT_IMPORTANCE, importance);
-            channel.setDescription(CHANNEL_DEFAULT_IMPORTANCE);
-            NotificationManager notificationManager = getSystemService(NotificationManager.class);
-            assert notificationManager != null;
-            notificationManager.createNotificationChannel(channel);
+            // Create the PendingIntent
+            PendingIntent notifyPendingIntent = PendingIntent.getActivity(
+                    this,
+                    0,
+                    new Intent(this.getApplicationContext(),MainActivity.class),
+                    PendingIntent.FLAG_UPDATE_CURRENT);
 
             // build a notification
             Notification notification =
                     new Notification.Builder(this, CHANNEL_DEFAULT_IMPORTANCE)
                             .setContentTitle(getText(R.string.app_name))
                             .setContentText("Active")
-                            //.setSmallIcon(R.drawable.icon)
-                            .setContentIntent(pendingIntent)
+                            .setSmallIcon(R.drawable.ic_notification_icon)
+                            .setAutoCancel(true)
+                            .setContentIntent(notifyPendingIntent)
                             .setTicker(getText(R.string.app_name))
                             .build();
 
@@ -294,6 +291,7 @@ public class CSCService extends Service {
             Notification notification = new NotificationCompat.Builder(this, CHANNEL_DEFAULT_IMPORTANCE)
                     .setContentTitle(getString(R.string.app_name))
                     .setContentText("Active")
+                    .setSmallIcon(R.drawable.ic_notification_icon)
                     .setPriority(NotificationCompat.PRIORITY_DEFAULT)
                     .setAutoCancel(true)
                     .build();

--- a/app/src/main/java/idv/markkuo/cscblebridge/MainActivity.java
+++ b/app/src/main/java/idv/markkuo/cscblebridge/MainActivity.java
@@ -5,18 +5,21 @@ import androidx.appcompat.app.AppCompatActivity;
 import android.annotation.SuppressLint;
 import android.app.ActivityManager;
 import android.content.BroadcastReceiver;
+import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
+import android.content.ServiceConnection;
 import android.os.Build;
 import android.os.Bundle;
+import android.os.IBinder;
 import android.util.Log;
 import android.view.View;
 import android.widget.Button;
 import android.widget.TextView;
 
 
-public class MainActivity extends AppCompatActivity {
+public class MainActivity extends AppCompatActivity  {
     private static final String TAG = MainActivity.class.getSimpleName();
 
     private TextView tv_speedSensorState, tv_cadenceSensorState, tv_hrSensorState,
@@ -26,6 +29,8 @@ public class MainActivity extends AppCompatActivity {
 
     private boolean serviceStarted = false;
     private MainActivityReceiver receiver;
+    private boolean mBound = false;
+    private CSCService mService;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -64,16 +69,54 @@ public class MainActivity extends AppCompatActivity {
                     Log.d(TAG, "Stopping Service");
                     MainActivity.this.stopService(i);
                 }
+
+                // Bind to the service so we can interact with it
+                if (!bindService(i, connection, Context.BIND_AUTO_CREATE)) {
+                    Log.d(TAG, "Failed to bind to service");
+                } else {
+                    mBound = true;
+                }
+
                 serviceStarted = !serviceStarted;
                 updateButtonState();
             }
         });
+
+        // Bind to the Sensor title and install a long click listener to restart searching for Speed sensor
+        findViewById(R.id.SpeedSensorText).setOnLongClickListener(createLongClickListener(() -> mService.startSpeedSensorSearch()));
+
+        // Bind to the Sensor title and install a long click listener to restart searching for Cadence sensor
+        findViewById(R.id.CadenceSensorText).setOnLongClickListener(createLongClickListener(() -> mService.startCadenceSensorSearch()));
+
+        // Bind to the Sensor title and install a long click listener to restart searching for HR sensor
+        findViewById(R.id.HRSensorText).setOnLongClickListener(createLongClickListener(() -> mService.startHRSensorSearch()));
 
         receiver = new MainActivityReceiver();
         // register intent from our service
         IntentFilter filter = new IntentFilter();
         filter.addAction("idv.markkuo.cscblebridge.ANTDATA");
         registerReceiver(receiver, filter);
+    }
+
+    // Allows for lambdas on the long click handler to reduce code duplication.
+    // TODO: Investigate to see if there is an existing interface we can use
+    interface DoAction {
+        void action();
+    }
+
+    // Long click handler for restarting scan for Ant+ devices
+    private View.OnLongClickListener createLongClickListener(final DoAction action) {
+        return new View.OnLongClickListener() {
+            @Override
+            public boolean onLongClick(View v) {
+                if (!serviceStarted || !mBound) {
+                    return false;
+                }
+
+                action.action();
+                return true;
+            }
+        };
     }
 
     private void updateButtonState() {
@@ -90,6 +133,22 @@ public class MainActivity extends AppCompatActivity {
         });
     }
 
+    /** Defines callbacks for service binding, passed to bindService() */
+    private ServiceConnection connection = new ServiceConnection() {
+
+        @Override
+        public void onServiceConnected(ComponentName className,  IBinder service) {
+            CSCService.LocalBinder binder = (CSCService.LocalBinder) service;
+            mService = binder.getService();
+            mBound = true;
+        }
+
+        @Override
+        public void onServiceDisconnected(ComponentName arg0) {
+            mBound = false;
+        }
+    };
+
     @Override
     protected void onResume() {
         super.onResume();
@@ -98,11 +157,20 @@ public class MainActivity extends AppCompatActivity {
         updateButtonState();
     }
 
+    // Unbind from the service
+    void unbindService() {
+        if (mBound) {
+            unbindService(connection);
+            mBound = false;
+        }
+    }
+
     @Override
     protected void onDestroy() {
         super.onDestroy();
 
         unregisterReceiver(receiver);
+        unbindService();
     }
 
     private void resetUi() {

--- a/app/src/main/java/idv/markkuo/cscblebridge/MainActivity.java
+++ b/app/src/main/java/idv/markkuo/cscblebridge/MainActivity.java
@@ -38,7 +38,7 @@ public class MainActivity extends AppCompatActivity {
 
         tv_speedSensorTimestamp = findViewById(R.id.SpeedTimestampText);
         tv_cadenceSensorTimestamp = findViewById(R.id.CadenceTimestampText);
-        tv_hrSensorTimestamp = findViewById(R.id.HRSensorStateText);
+        tv_hrSensorTimestamp = findViewById(R.id.HRTimestampText);
 
         tv_speed = findViewById(R.id.SpeedText);
         tv_cadence = findViewById(R.id.CadenceText);

--- a/app/src/main/res/drawable/ic_notification_icon.xml
+++ b/app/src/main/res/drawable/ic_notification_icon.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#009E41"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M12,5c-3.87,0 -7,3.13 -7,7h2c0,-2.76 2.24,-5 5,-5s5,2.24 5,5h2c0,-3.87 -3.13,-7 -7,-7zM13,14.29c0.88,-0.39 1.5,-1.26 1.5,-2.29 0,-1.38 -1.12,-2.5 -2.5,-2.5S9.5,10.62 9.5,12c0,1.02 0.62,1.9 1.5,2.29v3.3L7.59,21 9,22.41l3,-3 3,3L16.41,21 13,17.59v-3.3zM12,1C5.93,1 1,5.93 1,12h2c0,-4.97 4.03,-9 9,-9s9,4.03 9,9h2c0,-6.07 -4.93,-11 -11,-11z"/>
+</vector>


### PR DESCRIPTION
Creates bindings to support long pressing sensor names to rescan for the sensor. This allows for rescanning a device if the search has timed out, or otherwise lost connecting since starting.

This version uses lambdas to avoid code duplication, so also sets the Java version to 1.8.

The initialization of the various sensor searches has also been refactored into their own functions, so they can be reused for restarting the scan.