### PR TITLE
Support for long bluetooth device names

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ Special thanks to [pinkemma](https://github.com/pinkemma) who implements Heart R
 - Samsung Galaxy J5 2016 - Thanks [louisJ20](https://github.com/louisJ20)
 - Samsung Galaxy S9 (Android 10) - Thanks [pinkemma](https://github.com/pinkemma)
 - One Plus 7 Pro (Android 10) - Thanks [michaelrhughes](https://github.com/michaelrhughes)
-- Nokia 7 Plus (not sure, to be tested. 12/1/2021) - Thanks [leaskovski](https://github.com/leaskovski)
+- Nokia 7 Plus (Android 10) - Thanks [leaskovski](https://github.com/leaskovski)
+- Nexus 5 (CyanogenMod 13 and Ant+ Enabler) - Thanks [leaskovski](https://github.com/leaskovski)
 - OnePlus 5T (Android 10) - Thanks [philharle](https://github.com/philharle)
 - Galaxy Note 9 - Thanks [larryb84](https://github.com/larryb84)
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -23,7 +23,7 @@
             </intent-filter>
         </activity>
         <service android:name="idv.markkuo.cscblebridge.CSCService"
-            android:stopWithTask="true"
+            android:stopWithTask="false"
             android:label="CSCService">
         </service>
     </application>

--- a/app/src/main/java/idv/markkuo/cscblebridge/CSCService.java
+++ b/app/src/main/java/idv/markkuo/cscblebridge/CSCService.java
@@ -459,15 +459,18 @@ public class CSCService extends Service {
                 .setTxPowerLevel(AdvertiseSettings.ADVERTISE_TX_POWER_HIGH)
                 .build();
 
-        AdvertiseData data = new AdvertiseData.Builder()
-                .setIncludeDeviceName(true)
-                .setIncludeTxPowerLevel(false)
+        AdvertiseData advData = new AdvertiseData.Builder()
+                .setIncludeTxPowerLevel(true)
                 .addServiceUuid(new ParcelUuid(CSCProfile.CSC_SERVICE))
                 .addServiceUuid(new ParcelUuid(CSCProfile.HR_SERVICE))
                 .build();
 
+        AdvertiseData advScanResponse = new AdvertiseData.Builder()
+                .setIncludeDeviceName(true)
+                .build();
+
         mBluetoothLeAdvertiser
-                .startAdvertising(settings, data, mAdvertiseCallback);
+                .startAdvertising(settings, advData, advScanResponse, mAdvertiseCallback);
     }
 
     /**

--- a/app/src/main/java/idv/markkuo/cscblebridge/MainActivity.java
+++ b/app/src/main/java/idv/markkuo/cscblebridge/MainActivity.java
@@ -31,6 +31,7 @@ public class MainActivity extends AppCompatActivity  {
     private MainActivityReceiver receiver;
     private boolean mBound = false;
     private CSCService mService;
+    private Intent mServiceIntent;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -58,24 +59,27 @@ public class MainActivity extends AppCompatActivity  {
         btn_service.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                Intent i = new Intent(getApplicationContext(), CSCService.class);
                 if (!serviceStarted) {
+                    mServiceIntent = new Intent(getApplicationContext(), CSCService.class);
                     Log.d(TAG, "Starting Service");
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O)
-                        MainActivity.this.startForegroundService(i);
+                        MainActivity.this.startForegroundService(mServiceIntent);
                     else
-                        MainActivity.this.startService(i);
-                } else {
+                        MainActivity.this.startService(mServiceIntent);
+
+                    // Bind to the service so we can interact with it
+                    if (!bindService(mServiceIntent, connection, Context.BIND_AUTO_CREATE)) {
+                        Log.d(TAG, "Failed to bind to service");
+                    } else {
+                        mBound = true;
+                    }
+                }
+                else {
                     Log.d(TAG, "Stopping Service");
-                    MainActivity.this.stopService(i);
+                    unbindService();
+                    MainActivity.this.stopService(mServiceIntent);
                 }
 
-                // Bind to the service so we can interact with it
-                if (!bindService(i, connection, Context.BIND_AUTO_CREATE)) {
-                    Log.d(TAG, "Failed to bind to service");
-                } else {
-                    mBound = true;
-                }
 
                 serviceStarted = !serviceStarted;
                 updateButtonState();


### PR DESCRIPTION
Off the back of #11, it was suggested to change how the advertising is done....

Switched out the device name to be only included when responding to a scan request.  This saves on advertising space as we are limited to 31 octets, so now only the profiles (and powerlevel) are included in the single advertising data, which then triggers a response data when another device queries it.  This resolves long Bluetooth devices names as this would otherwise trigger a ADVERTISE_FAILED_DATA_TOO_LARGE error code